### PR TITLE
JSON log output and usage helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ Then, run `nomadlogs ls` to list instances
 
 Run `nomadlogs tail <task>` to tail all logs from all instances of `<task>`
 
-By default it uses `localhost:4646`.  To override this, set `NOMAD_ADDR=hostname:port`
+By default it uses `http://localhost:4646`.  To override this, set `NOMAD_ADDR=http://hostname:port`, 
+or pass `--addr=http://hostname:port` to the command line.

--- a/main.go
+++ b/main.go
@@ -16,6 +16,13 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
+const usage = "usage: nomadlogs [tail|ls] [flags] [job:task]...\n"
+
+func printUsageAndExit() {
+	fmt.Printf(usage)
+	os.Exit(1)
+}
+
 // always prefer the value specified at the command line
 // if one isn't specified at the command line, use env var NOMAD_ADDR
 // otherwise default to nomad's default address of http://127.0.0.1:4646
@@ -67,6 +74,9 @@ func NewTailCommand(n string, follow bool, addr string, tasks []string) (*tailCo
 		return nil, err
 	}
 	var nomadTasks []nomadTask
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("no tasks specified.\nUse 'nomadlogs tail [task]', or 'nomadlogs ls' to find tasks")
+	}
 	for _, task := range tasks {
 		split := strings.Split(task, ":")
 		if len(split) > 2 {
@@ -104,9 +114,10 @@ func main() {
 	lsCmd := flag.NewFlagSet("ls", flag.ExitOnError)
 	lsAddr := lsCmd.String("addr", "", "nomad address (e.g. http://127.0.0.1:4646)")
 
+	flag.Parse()
+
 	if len(os.Args) < 2 {
-		tailCmd.PrintDefaults()
-		os.Exit(1)
+		printUsageAndExit()
 	}
 
 	switch os.Args[1] {
@@ -172,6 +183,8 @@ func main() {
 		table.Render() // Send output
 	case "download":
 		fmt.Printf("not implemented yet\n")
+	default:
+		printUsageAndExit()
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -104,6 +104,11 @@ func main() {
 	lsCmd := flag.NewFlagSet("ls", flag.ExitOnError)
 	lsAddr := lsCmd.String("addr", "", "nomad address (e.g. http://127.0.0.1:4646)")
 
+	if len(os.Args) < 2 {
+		tailCmd.PrintDefaults()
+		os.Exit(1)
+	}
+
 	switch os.Args[1] {
 	case "tail":
 		tailCmd.Parse(os.Args[2:])


### PR DESCRIPTION
Frequently, I want JSON output, so I added that. I also forget how to use the tool and end up looking at the source code, so I added some usage info.


### Examples:
```
% nomadlogs     
Usage: nomadlogs [ls | tail] [flags] [job:task]...
  nomadlogs tail -h
  nomadlogs ls -h
```

```
% nomadlogs tail
nomadlogs 2024/07/26 16:40:59 NewTailCommand: no tasks specified

Usage of tail:
  nomadlogs tail [flags] [job:task]...
Flags:
  -addr string
        nomad address (also set via NOMAD_ADDR env var)
         (default "http://127.0.0.1:4646")
  -f    follow logs
  -json
        logs output as JSON
  -n string
        last n lines of logs use +NUM to start at line NUM (default "10")
```

```
% nomadlogs ls -h
Usage of ls:
  nomadlogs ls [flags]
Flags:
  -addr string
        nomad address (also set via NOMAD_ADDR env var)
         (default "http://127.0.0.1:4646")

```

N.b.: `nomad.DefaultConfig().Address` already handles the `NOMAD_ADDR` env var, so I deduped that.

```
% export NOMAD_ADDR=http://127.0.0.1:8888
% nomadlogs ls -h                         
Usage of ls:
  nomadlogs ls [flags]
Flags:
  -addr string
        nomad address (also set via NOMAD_ADDR env var)
         (default "http://127.0.0.1:8888")

```
